### PR TITLE
NANKAI-47: Fix for terminal.ReadPassword on Windows

### DIFF
--- a/internal/services/terminal.go
+++ b/internal/services/terminal.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"syscall"
 
 	"golang.org/x/crypto/ssh/terminal"
 
@@ -27,7 +28,7 @@ func StdinPrompt(prompt string) (string, error) {
 // StdinSecret ...
 func StdinSecret(prompt string) (string, error) {
 	fmt.Print(prompt)
-	byteSecret, err := terminal.ReadPassword(0)
+	byteSecret, err := terminal.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This resolve the defect when trying to read a password from stdin on Windows machines

Previously error occurred immediately `The handle is invalid.`