### PR TITLE
NANKAI-113: Add new commands - add-hook/remove-hook

### DIFF
--- a/cmd/hooks/add-hook.go
+++ b/cmd/hooks/add-hook.go
@@ -1,0 +1,33 @@
+package hooks
+
+import (
+	"fmt"
+	"os"
+
+	"gitlab.com/ironstar-io/ironstar-cli/cmd/flags"
+	"gitlab.com/ironstar-io/ironstar-cli/internal/api"
+	"gitlab.com/ironstar-io/ironstar-cli/internal/environment"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+// AddHookCmd - `iron environment add-hook [hookname]`
+var AddHookCmd = &cobra.Command{
+	Use:   "add-hook [hookname]",
+	Short: "Add environment hook",
+	Long:  "Add an environment hook (PRE_DEPLOYMENT_BACKUP)",
+	Run:   AddHook,
+}
+
+func AddHook(cmd *cobra.Command, args []string) {
+	err := environment.AddHook(args, flags.Acc)
+	if err != nil {
+		if err != api.ErrIronstarAPICall {
+			fmt.Println()
+			color.Red(err.Error())
+		}
+
+		os.Exit(1)
+	}
+}

--- a/cmd/hooks/main.go
+++ b/cmd/hooks/main.go
@@ -1,0 +1,1 @@
+package hooks

--- a/cmd/hooks/remove-hook.go
+++ b/cmd/hooks/remove-hook.go
@@ -1,0 +1,33 @@
+package hooks
+
+import (
+	"fmt"
+	"os"
+
+	"gitlab.com/ironstar-io/ironstar-cli/cmd/flags"
+	"gitlab.com/ironstar-io/ironstar-cli/internal/api"
+	"gitlab.com/ironstar-io/ironstar-cli/internal/environment"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+// RemoveHookCmd - `iron environment remove-hook [hookname]`
+var RemoveHookCmd = &cobra.Command{
+	Use:   "remove-hook [hookname]",
+	Short: "Remove environment hook",
+	Long:  "Remove an environment hook (PRE_DEPLOYMENT_BACKUP)",
+	Run:   RemoveHook,
+}
+
+func RemoveHook(cmd *cobra.Command, args []string) {
+	err := environment.RemoveHook(args, flags.Acc)
+	if err != nil {
+		if err != api.ErrIronstarAPICall {
+			fmt.Println()
+			color.Red(err.Error())
+		}
+
+		os.Exit(1)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"gitlab.com/ironstar-io/ironstar-cli/cmd/env_vars"
 	"gitlab.com/ironstar-io/ironstar-cli/cmd/environment"
 	"gitlab.com/ironstar-io/ironstar-cli/cmd/flags"
+	"gitlab.com/ironstar-io/ironstar-cli/cmd/hooks"
 	"gitlab.com/ironstar-io/ironstar-cli/cmd/logs"
 	"gitlab.com/ironstar-io/ironstar-cli/cmd/newrelic"
 	"gitlab.com/ironstar-io/ironstar-cli/cmd/pkg"
@@ -71,6 +72,11 @@ func init() {
 	environment.EnvCmd.AddCommand(environment.ListCmd)
 	environment.EnvCmd.AddCommand(environment.DisableRestoreCmd)
 	environment.EnvCmd.AddCommand(environment.EnableRestoreCmd)
+
+	// `iron add-hook x` alias
+	rootCmd.AddCommand(hooks.AddHookCmd)
+	// `iron remove-hook x` alias
+	rootCmd.AddCommand(hooks.RemoveHookCmd)
 
 	// `iron env-vars x` alias (hidden)
 	rootCmd.AddCommand(env_vars.EnvVarsCmd)

--- a/internal/api/environment.go
+++ b/internal/api/environment.go
@@ -90,6 +90,50 @@ func PatchEnvironment(creds types.Keylink, subHashOrAlias, envHashOrAlias, resto
 	return nil
 }
 
+func PostEnvironmentHook(creds types.Keylink, subHashOrAlias, envHashOrAlias, hookName string) error {
+	req := &Request{
+		RunTokenRefresh: true,
+		Credentials:     creds,
+		Method:          "POST",
+		Path:            "/subscription/" + subHashOrAlias + "/environment/" + envHashOrAlias + "/hook",
+		MapStringPayload: map[string]interface{}{
+			"hook": hookName,
+		},
+	}
+
+	res, err := req.NankaiSend()
+	if err != nil {
+		return errors.Wrap(err, errs.APIUpdateEnvironmentErrorMsg)
+	}
+
+	if res.StatusCode != 204 {
+		return res.HandleFailure()
+	}
+
+	return nil
+}
+
+func DeleteEnvironmentHook(creds types.Keylink, subHashOrAlias, envHashOrAlias, hookName string) error {
+	req := &Request{
+		RunTokenRefresh:  true,
+		Credentials:      creds,
+		Method:           "DELETE",
+		Path:             "/subscription/" + subHashOrAlias + "/environment/" + envHashOrAlias + "/hook/" + hookName,
+		MapStringPayload: map[string]interface{}{},
+	}
+
+	res, err := req.NankaiSend()
+	if err != nil {
+		return errors.Wrap(err, errs.APIUpdateEnvironmentErrorMsg)
+	}
+
+	if res.StatusCode != 204 {
+		return res.HandleFailure()
+	}
+
+	return nil
+}
+
 func GetEnvironmentContext(creds types.Keylink, flg flags.Accumulator, subHashOrAlias string) (types.Environment, error) {
 	empty := types.Environment{}
 

--- a/internal/constants/hooks.go
+++ b/internal/constants/hooks.go
@@ -1,0 +1,5 @@
+package constants
+
+const (
+	PRE_DEPLOYMENT_BACKUP = "PRE_DEPLOYMENT_BACKUP"
+)

--- a/internal/environment/hooks.go
+++ b/internal/environment/hooks.go
@@ -1,0 +1,105 @@
+package environment
+
+import (
+	"fmt"
+
+	"gitlab.com/ironstar-io/ironstar-cli/cmd/flags"
+	"gitlab.com/ironstar-io/ironstar-cli/internal/api"
+	"gitlab.com/ironstar-io/ironstar-cli/internal/constants"
+	"gitlab.com/ironstar-io/ironstar-cli/internal/services"
+
+	"github.com/fatih/color"
+	"github.com/pkg/errors"
+)
+
+func AddHook(args []string, flg flags.Accumulator) error {
+	creds, err := services.ResolveUserCredentials(flg.Login)
+	if err != nil {
+		return err
+	}
+
+	seCtx, err := api.GetSubscriptionEnvironmentContext(creds, flg)
+	if err != nil {
+		return err
+	}
+
+	if seCtx.Subscription.Alias == "" {
+		return errors.New("No Ironstar subscription has been linked to this project. Have you run `iron subscription link [subscription-name]`")
+	}
+
+	color.Green("Using login [" + creds.Login + "] for subscription '" + seCtx.Subscription.Alias + "' (" + seCtx.Subscription.HashedID + ")")
+
+	hookName, err := GetHookName(args)
+	if err != nil {
+		return err
+	}
+
+	err = api.PostEnvironmentHook(creds, seCtx.Subscription.HashedID, seCtx.Environment.HashedID, hookName)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println()
+	color.Green("The hook '" + hookName + "' has successfully been added to your environment")
+
+	if hookName == constants.PRE_DEPLOYMENT_BACKUP {
+		fmt.Println()
+		color.Yellow("Please note: There is limit of 20 backups per subscription that applies. When deploying to your environments with this hook enabled, automatically provisioned backups will contribute to this total.")
+	}
+
+	return nil
+}
+
+func RemoveHook(args []string, flg flags.Accumulator) error {
+	creds, err := services.ResolveUserCredentials(flg.Login)
+	if err != nil {
+		return err
+	}
+
+	seCtx, err := api.GetSubscriptionEnvironmentContext(creds, flg)
+	if err != nil {
+		return err
+	}
+
+	if seCtx.Subscription.Alias == "" {
+		return errors.New("No Ironstar subscription has been linked to this project. Have you run `iron subscription link [subscription-name]`")
+	}
+
+	color.Green("Using login [" + creds.Login + "] for subscription '" + seCtx.Subscription.Alias + "' (" + seCtx.Subscription.HashedID + ")")
+
+	hookName, err := GetHookName(args)
+	if err != nil {
+		return err
+	}
+
+	confirmRemove := services.ConfirmationPrompt("Are you sure you would like to remove the hook '"+hookName+"' from your environment?", "y", flg.AutoAccept)
+	if !confirmRemove {
+		fmt.Println("Exiting...")
+		return nil
+	}
+
+	err = api.DeleteEnvironmentHook(creds, seCtx.Subscription.HashedID, seCtx.Environment.HashedID, hookName)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println()
+	color.Green("The hook '" + hookName + "' has successfully been removed from your environment")
+
+	return nil
+}
+
+func GetHookName(args []string) (string, error) {
+	var name string
+	if len(args) == 0 {
+		input, err := services.StdinPrompt("Hook Name: ")
+		if err != nil {
+			return "", err
+		}
+		name = input
+	} else {
+		name = args[0]
+	}
+
+	return name, nil
+}


### PR DESCRIPTION
Adds the ability for users to be able to add/remove hooks from their environments. Currently only 'PRE_DEPLOY_BACKUP' is supported.

Requires Nankai release v4.45.x