### PR TITLE
Add ability to download latest backup with a flag

### DIFF
--- a/cmd/flags/main.go
+++ b/cmd/flags/main.go
@@ -39,6 +39,7 @@ type Accumulator struct {
 	CustomPackage     string
 	SrcEnvironment    string
 	DestEnvironment   string
+	Latest            bool
 	UseLatestBackup   bool
 	LockSessionToIP   bool
 	Timeout           int

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -203,6 +203,7 @@ func RootCmd() *cobra.Command {
 	backup.NewCmd.PersistentFlags().BoolVarP(&flags.Acc.LockTables, "lock-tables", "", false, "Pass the `--lock-tables` flag to mysqldump")
 	backup.DownloadCmd.PersistentFlags().StringVarP(&flags.Acc.SavePath, "save-path", "", "", "Select a custom save path for your backup download. Default: ./.ironstar/backups/{subscription}/{environment}")
 	backup.DownloadCmd.PersistentFlags().StringVarP(&flags.Acc.Backup, "backup", "", "", "Select the backup to be the base for download")
+	backup.DownloadCmd.PersistentFlags().BoolVarP(&flags.Acc.Latest, "latest", "", false, "Automatically select the latest available backup to be the base for download. Must set or supply an environment.")
 	backup.ListCmd.PersistentFlags().StringVarP(&flags.Acc.BackupType, "backup-type", "", "", "Filter the backup types to return. Either 'manual' or 'scheduled'")
 	backup.InfoCmd.PersistentFlags().StringVarP(&flags.Acc.BackupType, "backup-type", "", "", "Filter the backup types to return. Either 'manual' or 'scheduled'")
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/fatih/color v1.15.0
 	github.com/gernest/wow v0.1.0
 	github.com/ironstar-io/cron v0.0.0-20200911073046-f389219e1823
+	github.com/jinzhu/copier v0.4.0
 	github.com/metal3d/go-slugify v0.0.0-20160607203414-7ac2014b2f23
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ironstar-io/cron v0.0.0-20200911073046-f389219e1823 h1:dXW8+jKixqYXNRvbRWoHsoG9Y7AeUrfPPnq7vq4SZyQ=
 github.com/ironstar-io/cron v0.0.0-20200911073046-f389219e1823/go.mod h1:EQhAerZrmar5XCJ1g535zhsVDmEkshTgj9Fi2fg2V2E=
+github.com/jinzhu/copier v0.4.0 h1:w3ciUoD19shMCRargcpm0cm91ytaBhDvuRpz1ODO/U8=
+github.com/jinzhu/copier v0.4.0/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/internal/backup/download.go
+++ b/internal/backup/download.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ironstar-io/ironstar-cli/internal/types"
 
 	"github.com/fatih/color"
+	"github.com/jinzhu/copier"
 	slugify "github.com/metal3d/go-slugify"
 	"github.com/pkg/errors"
 )
@@ -37,31 +38,26 @@ func Download(args []string, flg flags.Accumulator) error {
 
 	utils.PrintCommandContext(flg.Output, creds.Login, sCtx.Alias, sCtx.HashedID)
 
-	backupName, err := GetBackupName(args, flg.Backup)
-	if err != nil {
-		return err
-	}
-
 	reqComps := utils.CalculateBackupComponents(flg.Component)
 
-	b, err := api.GetSubscriptionBackup(creds, flg.Output, sCtx.HashedID, backupName, constants.DISPLAY_ERRORS)
+	b, err := getTargetBackup(args, flg, creds, sCtx.HashedID)
 	if err != nil {
 		return err
 	}
 
-	dlComps, err := matchDownloadComponents(reqComps, b.BackupIteration.Components)
+	dlComps, err := matchDownloadComponents(reqComps, b.Components)
 	if err != nil {
 		return err
 	}
 
-	savePath, err := calcSavePath(flg.SavePath, sCtx.Alias, b.BackupIteration.EnvironmentName, backupName)
+	savePath, err := calcSavePath(flg.SavePath, sCtx.Alias, b.EnvironmentName, b.Iteration)
 	if err != nil {
 		return err
 	}
 
 	fmt.Println()
 
-	confirmDL := services.ConfirmationPrompt("Backup downloads are included in your outbound bandwidth allocation each month.\n\nAre you sure you want to download this backup?", "y", flg.AutoAccept)
+	confirmDL := services.ConfirmationPrompt(fmt.Sprintf("Backup downloads are included in your outbound bandwidth allocation each month.\n\nAre you sure you want to download the backup '%s'?", b.Iteration), "y", flg.AutoAccept)
 	if !confirmDL {
 		fmt.Println("Exiting...")
 		return nil
@@ -72,7 +68,7 @@ func Download(args []string, flg flags.Accumulator) error {
 	for _, dlComp := range dlComps {
 		file := calcFilename(savePath, dlComp.Name)
 
-		err = api.DownloadEnvironmentBackupComponent(creds, flg.Output, sCtx.HashedID, b.BackupIteration.EnvironmentName, backupName, file, dlComp)
+		err = api.DownloadEnvironmentBackupComponent(creds, flg.Output, sCtx.HashedID, b.EnvironmentName, b.Iteration, file, dlComp)
 		if err != nil {
 			return err
 		}
@@ -82,6 +78,42 @@ func Download(args []string, flg flags.Accumulator) error {
 	color.Green("Download completed and saved to " + savePath)
 
 	return nil
+}
+
+func getTargetBackup(args []string, flg flags.Accumulator, creds types.Keylink, subHashedId string) (*types.BackupIteration, error) {
+	if flg.Latest {
+		env, err := api.GetEnvironmentContext(creds, flg, subHashedId)
+		if err != nil {
+			return nil, err
+		}
+
+		b, err := api.GetLatestEnvironmentBackupIteration(creds, flg.Output, subHashedId, env.HashedID)
+		if err != nil {
+			return nil, err
+		}
+		b.EnvironmentName = env.Name
+
+		return &b, nil
+	}
+
+	backupName, err := GetBackupName(args, flg.Backup)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := api.GetSubscriptionBackup(creds, flg.Output, subHashedId, backupName, constants.DISPLAY_ERRORS)
+	if err != nil {
+		return nil, err
+	}
+
+	nbr := &types.BackupIteration{}
+	err = copier.Copy(nbr, b.BackupIteration)
+	if err != nil {
+		return nil, err
+	}
+	nbr.BackupRequest = b.BackupRequest
+
+	return nbr, nil
 }
 
 func matchDownloadComponents(reqComps []string, buComps []types.BackupIterationComponent) ([]types.BackupIterationComponent, error) {


### PR DESCRIPTION
Add ability to download the latest backup automatically with the flag `--latest`. Must specify an environment using flag `--env` or via prompt in conjunction with the latest flag.

Example
```sh
iron backup download --latest --env dev
```

```sh
iron backup download --latest
# Environment ID or Name: stage
```

As normal, you can skip the confirmation prompt with `-y`