### PR TITLE
Fix custom package logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION_PATH ?= github.com/ironstar-io/ironstar-cli/internal/system/version
 BUILD_DATE   ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 VERSION      ?= $(shell git describe --tags)
-GO_IMAGE     ?= golang:1.21
+GO_IMAGE     ?= golang:1.22
 
 DOCKER_SCRIPT=docker run --rm \
 		-v $(PWD)/.cache/go:/.cache \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ironstar-io/ironstar-cli
 
-go 1.21
+go 1.22
 
 require (
 	github.com/blang/semver v3.5.1+incompatible

--- a/internal/api/req.go
+++ b/internal/api/req.go
@@ -181,9 +181,6 @@ func (r *Request) HTTPSDownload(filepath, friendlyName string) (*RawResponse, er
 		out.Close()
 		return nil, err
 	}
-	if err != nil {
-		return nil, err
-	}
 
 	ir := &RawResponse{
 		StatusCode: resp.StatusCode,

--- a/internal/api/upload.go
+++ b/internal/api/upload.go
@@ -15,7 +15,7 @@ import (
 
 // UploadPackage - Create a project tarball in tmp
 func UploadPackage(creds types.Keylink, subHash, tarpath string, flg flags.Accumulator) (*RawResponse, error) {
-	if flg.CustomPackage != "" {
+	if flg.CustomPackage == "" {
 		color.Red(`Warning! This command uploads the contents of this directory to your Ironstar Subscription. Only paths listed under the "exclude" settings in your .ironstar/config.yml file will be excluded.
 
 This means that any database files, .env files, or other potentially sensitive content that you have in this repository that is not in the exclude list will be uploaded to the remote environment and possibly made publicly visible.
@@ -60,6 +60,10 @@ Please proceed with caution.
 			if err != nil {
 				console.SpinPersist(wo, "⛔", "There was an error while uploading the package\n")
 				return nil, err
+			}
+			if res.StatusCode < 199 || res.StatusCode > 299 {
+				console.SpinPersist(wo, "⛔", "There was an error while uploading the package\n")
+				return nil, fmt.Errorf("an error occurred with status %d: %s", res.StatusCode, res.Body)
 			}
 
 			console.SpinPersist(wo, "💾", "Package upload completed successfully!\n")


### PR DESCRIPTION
- When using --custom-package flag, the warning message was showing incorrectly
- Unsuccessful uploads were retaining the `Uploading...` message when it should be a failure message