### PR TITLE
ci(release): NANKAI-697 Pin goreleaser version to triggering tag -ai

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,12 @@ jobs:
 
       - name: GoReleaser build + sign (skip publish)
         uses: goreleaser/goreleaser-action@v6
+        env:
+          # Pin the version to the triggering tag so the build never relies on
+          # `git describe`, which is ambiguous when an rc tag and the final tag
+          # point at the same commit. Empty on non-tag dispatch, where
+          # goreleaser falls back to its own resolution.
+          GORELEASER_CURRENT_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
         with:
           distribution: goreleaser
           version: v2.15.4


### PR DESCRIPTION
Promoting a prerelease by renaming its GitHub release left the v1.8.0 assets stamped 1.8.0-rc1. GoReleaser derives the version from git describe, which is ambiguous when an rc tag and the final tag share a commit. Setting GORELEASER_CURRENT_TAG from the triggering tag ref makes the build authoritative; it is empty on non-tag dispatch so existing resolution still applies.

Coding-Agent: Claude Code
Model: claude-opus-4-8